### PR TITLE
Hotfix - Only displaying not yet passed intro courses

### DIFF
--- a/client/src/management/ManagementConsole.tsx
+++ b/client/src/management/ManagementConsole.tsx
@@ -104,7 +104,11 @@ export const ManagementConsole = ({
 
   useEffect(() => {
     let restrictedCourseIterations = fetchedCourseIterations
-    if (user && permissions.includes(Permission.TUTOR.toString())) {
+    if (
+      user &&
+      permissions.includes(Permission.TUTOR.toString()) &&
+      !permissions.includes(Permission.PM.toString())
+    ) {
       restrictedCourseIterations = fetchedCourseIterations?.filter((courseIteration) => {
         const introCourseEnd = new Date(courseIteration.introCourseEnd)
         // Only show course iterations to Tutors that have not ended yet

--- a/client/src/management/ManagementConsole.tsx
+++ b/client/src/management/ManagementConsole.tsx
@@ -25,6 +25,7 @@ import { useCourseIterationStore } from '../state/zustand/useCourseIterationStor
 import { CourseIteration } from '../interface/courseIteration'
 import { getCourseIterations } from '../network/courseIteration'
 import { useAuthenticationStore } from '../state/zustand/useAuthenticationStore'
+import { Permission } from '../interface/authentication'
 
 export const ManagementRoot = (): JSX.Element => {
   const [greetingMounted, setGreetingsMounted] = useState(false)
@@ -86,7 +87,7 @@ export const ManagementConsole = ({
   onKeycloakValueChange,
 }: ManagmentConsoleProps): JSX.Element => {
   const [scroll, scrollTo] = useWindowScroll()
-  const { user, setUser, setPermissions } = useAuthenticationStore()
+  const { user, permissions, setUser, setPermissions } = useAuthenticationStore()
   const [authenticated, setAuthenticated] = useState(false)
   const {
     selectedCourseIteration,
@@ -102,8 +103,16 @@ export const ManagementConsole = ({
   })
 
   useEffect(() => {
-    setCourseIterations(fetchedCourseIterations ?? [])
-  }, [fetchedCourseIterations, setCourseIterations])
+    let restrictedCourseIterations = fetchedCourseIterations
+    if (user && permissions.includes(Permission.TUTOR.toString())) {
+      restrictedCourseIterations = fetchedCourseIterations?.filter((courseIteration) => {
+        const introCourseEnd = new Date(courseIteration.introCourseEnd)
+        // Only show course iterations to Tutors that have not ended yet
+        return introCourseEnd.getTime() > Date.now()
+      })
+    }
+    setCourseIterations(restrictedCourseIterations ?? [])
+  }, [fetchedCourseIterations, permissions, setCourseIterations, user])
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const keycloak = new Keycloak({


### PR DESCRIPTION
This PR restricts Tutors to only be able to see the current intro course and not intro courses of the last semesters. 

In the long run, this shall be managed through more fine granular access groups. 