### PR TITLE
fixing spring boot vulnerability vulnerability

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -25,8 +25,12 @@ repositories {
 }
 
 dependencies {
+	implementation("org.springframework.boot:spring-boot-starter-web") {
+		exclude group: 'org.apache.tomcat.embed', module: 'tomcat-embed-core'
+	}
+	implementation "org.apache.tomcat.embed:tomcat-embed-core:10.1.34"
+
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.postgresql:postgresql'


### PR DESCRIPTION
Manually upgrade Spring Boot to address Tomcat vulnerability

The latest available Spring Boot release does not yet include the Tomcat 
security fix. As a workaround, this commit updates the Spring Boot version 
manually to a release that includes the necessary patch, ensuring the 
application is protected from the known vulnerability.