### PR TITLE
Redirection Students to new Page

### DIFF
--- a/client/src/utilities/LandingPage/LandingPage.tsx
+++ b/client/src/utilities/LandingPage/LandingPage.tsx
@@ -1,5 +1,5 @@
-import { Button, Card, Group, Stack, Title } from '@mantine/core'
-import { IconBrandSwift, IconLogin, IconSchool, IconUsersGroup } from '@tabler/icons-react'
+import { Button, Card, Group, Stack, Text, Title } from '@mantine/core'
+import { IconDirection, IconDirections, IconLogin } from '@tabler/icons-react'
 import { useNavigate } from 'react-router-dom'
 import * as styles from './LandingPage.module.scss'
 import { Footer } from './components/Footer'
@@ -16,34 +16,20 @@ export const LandingPage = (): JSX.Element => {
           </Button>
         </Group>
         <div className={styles.menu}>
-          <Card withBorder p='xl'>
-            <Stack>
-              <Title order={5}>
-                Please select the practical course you want to apply for from the list below.
+          <Card withBorder shadow='sm' radius='md' p='xl' mb='xl'>
+            <Stack align='center'>
+              <IconDirections size={64} color='gray' />
+              <Title order={4} className={styles.cardTitle} ta='center'>
+                Looking to apply for courses at the Research Group for Applied Education
+                Technologies?
               </Title>
+              <Text className={styles.cardText}>We have moved to our new application tool.</Text>
               <Button
-                onClick={() => {
-                  navigate('/applications/developer')
-                }}
-                leftSection={<IconBrandSwift />}
+                size='lg'
+                onClick={() => (window.location.href = 'https://prompt.aet.cit.tum.de')}
+                className={styles.cardButton}
               >
-                iPraktikum
-              </Button>
-              <Button
-                onClick={() => {
-                  navigate('/applications/coach')
-                }}
-                leftSection={<IconUsersGroup />}
-              >
-                Agile Project Management
-              </Button>
-              <Button
-                onClick={() => {
-                  navigate('/applications/tutor')
-                }}
-                leftSection={<IconSchool />}
-              >
-                Teaching iOS
+                Go to the New Application Tool
               </Button>
             </Stack>
           </Card>


### PR DESCRIPTION
## Problem
With the new semester we want to transition to the new Prompt2. 
But for the current semester we are still using the "old" prompt, and it needs to stay functional to finish the grading of the ongoing semester. Thus, we cannot just deploy the new prompt under the same URL.

Hence the deployed the new Prompt under "prompt.aet" (instead of ase). 
To prevent students (who might somehow click an old Link) trying to apply at the old tool, I modified the Landing Page:

<img width="1321" alt="image" src="https://github.com/user-attachments/assets/07717710-bb33-4554-92c1-c13b7a6cddc8" />




After shutting off Prompt 1 completely, we will also redirect the "old" prompt.ase. to the new prompt.aet.